### PR TITLE
Error on empty client params.

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -143,6 +143,11 @@ func (b *DeployerAccountBroker) Bind(
 	switch details.ServiceID {
 	case clientAccountGUID:
 		var opts BindOptions
+
+		if len(details.RawParameters) == 0 {
+			return brokerapi.Binding{}, errors.New(`Must pass JSON configuration with field "redirect_uri"`)
+		}
+
 		if err := json.Unmarshal(details.RawParameters, &opts); err != nil {
 			return brokerapi.Binding{}, err
 		}


### PR DESCRIPTION
So that users don't get a 500 if they forget to pass a config json blob when creating a uaa client. Caught this pairing with @timothy-spencer.