### PR TITLE
Drop dashboard migration notice.

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -90,10 +90,7 @@ func (b *DeployerAccountBroker) Provision(
 	details brokerapi.ProvisionDetails,
 	asyncAllowed bool,
 ) (brokerapi.ProvisionedServiceSpec, error) {
-	// TODO: Drop after 2017-07-12
-	return brokerapi.ProvisionedServiceSpec{
-		DashboardURL: "https://cloud.gov/updates/2017-07-05-changes-to-credentials-broker/",
-	}, nil
+	return brokerapi.ProvisionedServiceSpec{}, nil
 }
 
 func (b *DeployerAccountBroker) Deprovision(


### PR DESCRIPTION
This is a broken link that we don't need anymore.