### PR TITLE
Yank cloud_controller.read as allowed scope

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -28,7 +28,6 @@ var (
 	defaultScopes = []string{"openid"}
 	allowedScopes = map[string]bool{
 		"openid":                true,
-		"cloud_controller.read": true,
 	}
 )
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -153,7 +153,7 @@ var _ = Describe("broker", func() {
 				uaaClient.On("CreateClient", Client{
 					ID:                   "binding-guid",
 					AuthorizedGrantTypes: []string{"authorization_code", "refresh_token"},
-					Scope:                []string{"openid", "cloud_controller.read"},
+					Scope:                []string{"openid"},
 					RedirectURI:          []string{"https://cloud.gov"},
 					ClientSecret:         "password",
 					AccessTokenValidity:  600,
@@ -167,7 +167,7 @@ var _ = Describe("broker", func() {
 					brokerapi.BindDetails{
 						AppGUID:       "app-guid",
 						ServiceID:     clientAccountGUID,
-						RawParameters: []byte(`{"redirect_uri": ["https://cloud.gov"], "scopes": ["openid", "cloud_controller.read"]}`),
+						RawParameters: []byte(`{"redirect_uri": ["https://cloud.gov"], "scopes": ["openid"]}`),
 					},
 				)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This scope, `cloud_controller.read` allows a would-be bad actor to read information about environment from apps when users don't carefully read granted permissions. May add `cloud_controller.global_auditor` in the future for a safer version.