### PR TITLE
Verify cflinuxfs4

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,4 @@ applications:
   buildpacks:
   - https://github.com/cloudfoundry/go-buildpack
   env:
-    GOVERSION: go1.12
+    GOVERSION: go1.20

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,6 @@
 applications:
 - name: uaa-credentials-broker
   command: uaa-credentials-broker
-  stack: cflinuxfs4
   buildpacks:
   - https://github.com/cloudfoundry/go-buildpack
   env:

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,6 @@ applications:
   command: uaa-credentials-broker
   stack: cflinuxfs4
   buildpacks:
-  - https://github.com/cloudfoundry/go-buildpack#v1.8.40
+  - https://github.com/cloudfoundry/go-buildpack
   env:
     GOVERSION: go1.12

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
 - name: uaa-credentials-broker
   command: uaa-credentials-broker
+  stack: cflinuxfs4
   buildpacks:
   - https://github.com/cloudfoundry/go-buildpack#v1.8.40
   env:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -544,9 +544,7 @@ resources:
   type: git
   source:
     uri: ((broker-git-url))
-      #branch: ((broker-git-branch))
-    branch: verify-cflinuxfs4
-
+    branch: ((broker-git-branch))
 
 - name: pipeline-tasks
   type: git

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -544,7 +544,9 @@ resources:
   type: git
   source:
     uri: ((broker-git-url))
-    branch: ((broker-git-branch))
+      #branch: ((broker-git-branch))
+    branch: verify-cflinuxfs4
+
 
 - name: pipeline-tasks
   type: git


### PR DESCRIPTION
Updated the manifest to remove the cflinuxfs4 configuration. This PR effectively updates the go build pack to the current version and the GOVERSION to the corresponding Go version.